### PR TITLE
Separate circle color property options for when the large map is active

### DIFF
--- a/WhereTheCirclesAt.cs
+++ b/WhereTheCirclesAt.cs
@@ -46,7 +46,9 @@ public class WhereTheCirclesAt : BaseSettingsPlugin<WhereTheCirclesAtSettings>
                     ImGui.DragInt("Segments (high = bad)", ref item.Segments);
                     ImGui.Checkbox("Draw in World", ref item.World);
                     ImGui.Checkbox("Draw on Large Map", ref item.LargeMap);
-                    item.Color = ColorPicker("Color", item.Color);
+                    ImGui.Checkbox("Large Map World Color", ref item.EnableLargeMapColor);
+                    item.LargeMapColor = ColorPicker("Active Large Map World Color", item.LargeMapColor);
+                    item.GameWorldColor = ColorPicker("Active World Color", item.GameWorldColor);
 
                     if (ImGui.Button("Delete"))
                     {
@@ -156,12 +158,16 @@ public class WhereTheCirclesAt : BaseSettingsPlugin<WhereTheCirclesAtSettings>
         {
             if (drawing.World)
             {
-                DrawData(drawing.Color, drawing.Size, drawing.Thickness, drawing.Segments);
+                var colorToUse = inGameUi.Map.LargeMap.IsVisible && drawing.EnableLargeMapColor
+                    ? drawing.LargeMapColor
+                    : drawing.GameWorldColor;
+
+                DrawData(colorToUse, drawing.Size, drawing.Thickness, drawing.Segments);
             }
 
-            if (drawing.LargeMap && GameController.Game.IngameState.IngameUi.Map.LargeMap.IsVisible)
+            if (drawing.LargeMap && inGameUi.Map.LargeMap.IsVisible)
             {
-                Graphics.DrawCircleOnLargeMap(GameController.Player.GridPosNum, false, drawing.Size, drawing.Color, drawing.Thickness, drawing.Segments);
+                Graphics.DrawCircleOnLargeMap(GameController.Player.GridPosNum, false, drawing.Size, drawing.GameWorldColor, drawing.Thickness, drawing.Segments);
             }
         }
 
@@ -170,7 +176,7 @@ public class WhereTheCirclesAt : BaseSettingsPlugin<WhereTheCirclesAtSettings>
 
         void DrawData(Color color, float size, int thickness, int segments)
         {
-            DrawCircleInWorld(PlayerPos, size*10f, color, thickness, segments);
+            DrawCircleInWorld(PlayerPos, size * 10f, color, thickness, segments);
         }
     }
 

--- a/WhereTheCirclesAtSettings.cs
+++ b/WhereTheCirclesAtSettings.cs
@@ -22,8 +22,10 @@ public class WhereTheCirclesAtSettings : ISettings
         public int Thickness;
         public int Segments;
         public bool LargeMap;
+        public bool EnableLargeMapColor;
+        public Color LargeMapColor;
         public bool World;
-        public Color Color;
+        public Color GameWorldColor;
 
         public CircleData()
         {
@@ -32,8 +34,10 @@ public class WhereTheCirclesAtSettings : ISettings
             Thickness = 7;
             Segments = 40;
             LargeMap = false;
+            EnableLargeMapColor = false;
+            LargeMapColor = Color.White;
             World = true;
-            Color = Color.White;
+            GameWorldColor = Color.White;
         }
     }
 }


### PR DESCRIPTION
Added the ability to have a toggle for separate color display properties for circles based on if the large overlay map is active or not and the new toggle setting is enabled. Example of use includes, setting different alpha values so that when the large overlay map is open, the game world circle is set to a lower alpha value to be less distracting. Refactored  old “Color” to “GameWorldColor” to be more descriptive now that there is more than 1 color property per item.